### PR TITLE
Initialize oclif CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# scol-js
+# scorton CLI
+
+Example CLI bootstrapped with [oclif](https://oclif.io/).
+
+## Usage
+
+```bash
+npm install
+yarn install # if you use yarn
+scorton hello --name world
+```

--- a/bin/run
+++ b/bin/run
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../src').run().catch(require('@oclif/core/handle'));

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "scortonjs",
+  "version": "0.1.0",
+  "description": "Example CLI",
+  "bin": {
+    "scorton": "bin/run"
+  },
+  "oclif": {
+    "commands": "./src/commands",
+    "bin": "scorton",
+    "plugins": ["@oclif/plugin-help"]
+  },
+  "dependencies": {
+    "@oclif/core": "^3.11.1",
+    "@oclif/plugin-help": "^5.2.19"
+  }
+}

--- a/src/commands/hello.js
+++ b/src/commands/hello.js
@@ -1,0 +1,16 @@
+const {Command, Flags} = require('@oclif/core');
+
+class HelloCommand extends Command {
+  async run() {
+    const {flags} = await this.parse(HelloCommand);
+    const name = flags.name || 'world';
+    this.log(`hello ${name}`);
+  }
+}
+
+HelloCommand.description = 'Say hello';
+HelloCommand.flags = {
+  name: Flags.string({char: 'n', description: 'name to print'}),
+};
+
+module.exports = HelloCommand;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+exports.run = require('@oclif/core').run;


### PR DESCRIPTION
## Summary
- create CLI skeleton using oclif
- add sample hello command
- update README with usage instructions

## Testing
- `node bin/run hello` *(fails: Cannot find module '@oclif/core')*
- `npm test` *(fails: Missing script 'test')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68441b3e08d88331bfb18086265d8f80