### PR TITLE
Add simple CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# scol-js
+# scortonjs
+
+## CLI Usage
+
+Install dependencies (none are required) and run the CLI with node:
+
+```bash
+node cli.js <command>
+```
+
+Available commands:
+
+- `hello`    prints a greeting message
+- `version`  prints the package version
+
+Without a command, help is shown.

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const [, , command] = process.argv;
+
+function showHelp() {
+  console.log('Usage: scortonjs <command>');
+  console.log('Commands:');
+  console.log('  hello    Print greeting');
+  console.log('  version  Print version');
+}
+
+switch (command) {
+  case 'hello':
+    console.log('Hello from scortonjs!');
+    break;
+  case 'version':
+    const pkg = JSON.parse(
+      readFileSync(join(__dirname, 'package.json'), 'utf8')
+    );
+    console.log(pkg.version);
+    break;
+  default:
+    showHelp();
+    break;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "scortonjs",
+  "version": "1.0.0",
+  "description": "Simple CLI demo",
+  "bin": {
+    "scortonjs": "./cli.js"
+  },
+  "type": "module"
+}


### PR DESCRIPTION
## Summary
- add a Node-based CLI with `hello` and `version` commands
- document usage in README
- define package.json with executable entry

## Testing
- `node cli.js hello`
- `node cli.js version`
- `node cli.js`

------
https://chatgpt.com/codex/tasks/task_e_68441b512e988331a1dd7aa1750bbc8a