### PR TITLE
Add scaffold commands with placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,8 @@ Available commands:
 
 - `hello`    prints a greeting message
 - `version`  prints the package version
+- `init`     initializes a project *(not implemented yet)*
+- `generate` scaffolds code *(not implemented yet)*
+- `build`    builds project artifacts *(not implemented yet)*
 
 Without a command, help is shown.

--- a/cli.js
+++ b/cli.js
@@ -12,19 +12,27 @@ function showHelp() {
   console.log('Commands:');
   console.log('  hello    Print greeting');
   console.log('  version  Print version');
+  console.log('  init     Initialize project (not implemented)');
+  console.log('  generate Generate code (not implemented)');
+  console.log('  build    Build project (not implemented)');
 }
 
-switch (command) {
-  case 'hello':
-    console.log('Hello from scortonjs!');
-    break;
-  case 'version':
-    const pkg = JSON.parse(
-      readFileSync(join(__dirname, 'package.json'), 'utf8')
-    );
-    console.log(pkg.version);
-    break;
-  default:
-    showHelp();
-    break;
-}
+  switch (command) {
+    case 'hello':
+      console.log('Hello from scortonjs!');
+      break;
+    case 'version':
+      const pkg = JSON.parse(
+        readFileSync(join(__dirname, 'package.json'), 'utf8')
+      );
+      console.log(pkg.version);
+      break;
+    case 'init':
+    case 'generate':
+    case 'build':
+      console.log('Not implemented yet.');
+      break;
+    default:
+      showHelp();
+      break;
+  }


### PR DESCRIPTION
## Summary
- add placeholder cases for `init`, `generate` and `build` in `cli.js`
- document planned commands in README

## Testing
- `node cli.js init`
- `node cli.js version`
- `node cli.js`

------
https://chatgpt.com/codex/tasks/task_e_685b4a825d4c833187fe52e98b7c4c9a