### PR TITLE
Add Vitest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ Available commands:
 - `version`  prints the package version
 
 Without a command, help is shown.
+
+## Running Tests
+
+Install dev dependencies and run:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -5,5 +5,11 @@
   "bin": {
     "scortonjs": "./cli.js"
   },
-  "type": "module"
+  "type": "module",
+  "scripts": {
+    "test": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^1.0.0"
+  }
 }

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -1,0 +1,21 @@
+import { execFileSync } from 'child_process';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { readFileSync } from 'fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI_PATH = join(__dirname, '..', 'cli.js');
+const PKG_PATH = join(__dirname, '..', 'package.json');
+
+describe('scortonjs CLI', () => {
+  it('prints greeting for hello command', () => {
+    const output = execFileSync('node', [CLI_PATH, 'hello'], { encoding: 'utf8' });
+    expect(output.trim()).toBe('Hello from scortonjs!');
+  });
+
+  it('prints version number for version command', () => {
+    const output = execFileSync('node', [CLI_PATH, 'version'], { encoding: 'utf8' });
+    const pkg = JSON.parse(readFileSync(PKG_PATH, 'utf8'));
+    expect(output.trim()).toBe(pkg.version);
+  });
+});


### PR DESCRIPTION
## Summary
- set up Vitest with test script
- document testing in README
- cover hello and version commands with unit tests

## Testing
- `npx vitest run` *(fails: E403 Forbidden)*
- `npm test --silent` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b4a7ea4188331b8ccfd0e4c03a9b1